### PR TITLE
add FindString & Port to parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Ansible 2.2+
 | timeout              | false    | Timeout in seconds                                                                            | 30             |
 | status_codes         | false    | Comma seperated list of StatusCodes to trigger error on                                       | Stantard codes |
 | find_string          | false    | A string to look for in the response; trigger when it is not there                            |                |
+| port                 | false    | Port to check for TCP tests                                                                   |                |
 
 ### Example usage:
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Ansible 2.2+
 | confirmation         | false    | Alert delay rate                                                                              | 300            |
 | timeout              | false    | Timeout in seconds                                                                            | 30             |
 | status_codes         | false    | Comma seperated list of StatusCodes to trigger error on                                       | Stantard codes |
+| find_string          | false    | A string to look for in the response; trigger when it is not there                            |                |
 
 ### Example usage:
 

--- a/library/statuscake.py
+++ b/library/statuscake.py
@@ -6,7 +6,7 @@ class StatusCake:
     URL_ALL_TESTS = "https://app.statuscake.com/API/Tests"
     URL_DETAILS_TEST = "https://app.statuscake.com/API/Tests/Details"
 
-    def __init__(self, module, username, api_key, name, url, state, test_tags, check_rate, test_type, contact_group, user_agent, paused, node_locations, confirmation, timeout, status_codes):
+    def __init__(self, module, username, api_key, name, url, state, test_tags, check_rate, test_type, contact_group, user_agent, paused, node_locations, confirmation, timeout, status_codes, find_string):
         self.headers = {"Username": username, "API": api_key}
         self.module = module
         self.name = name
@@ -21,6 +21,7 @@ class StatusCake:
         self.confirmation = confirmation
         self.timeout = timeout
         self.status_codes = status_codes
+        self.find_string = find_string
 
         if not check_rate:
             self.check_rate = 300
@@ -68,7 +69,9 @@ class StatusCake:
                 "NodeLocations": self.node_locations,
                 "Confirmation": self.confirmation,
                 "Timeout": self.timeout,
-                "StatusCodes": self.status_codes}
+                "StatusCodes": self.status_codes,
+                "FindString": self.find_string,
+        }
 
         test_id = self.check_test()
         
@@ -98,6 +101,7 @@ def run_module():
         confirmation=dict(type='int', required=False),
         timeout=dict(type='int', required=False),
         status_codes=dict(type='str', required=False),
+        find_string=dict(type='str', required=False),
     )
 
     module = AnsibleModule(argument_spec=module_args, supports_check_mode=False)
@@ -117,8 +121,9 @@ def run_module():
     confirmation = module.params['confirmation']
     timeout = module.params['timeout']
     status_codes = module.params['status_codes']
+    find_string = module.params['find_string']
 
-    test = StatusCake(module, username, api_key, name, url, state, test_tags, check_rate, test_type, contact_group, user_agent, paused, node_locations, confirmation, timeout, status_codes)
+    test = StatusCake(module, username, api_key, name, url, state, test_tags, check_rate, test_type, contact_group, user_agent, paused, node_locations, confirmation, timeout, status_codes, find_string)
 
     if state == "absent":
         test.delete_test()

--- a/library/statuscake.py
+++ b/library/statuscake.py
@@ -6,7 +6,7 @@ class StatusCake:
     URL_ALL_TESTS = "https://app.statuscake.com/API/Tests"
     URL_DETAILS_TEST = "https://app.statuscake.com/API/Tests/Details"
 
-    def __init__(self, module, username, api_key, name, url, state, test_tags, check_rate, test_type, contact_group, user_agent, paused, node_locations, confirmation, timeout, status_codes, find_string):
+    def __init__(self, module, username, api_key, name, url, state, test_tags, check_rate, test_type, contact_group, user_agent, paused, node_locations, confirmation, timeout, status_codes, find_string, port):
         self.headers = {"Username": username, "API": api_key}
         self.module = module
         self.name = name
@@ -22,6 +22,7 @@ class StatusCake:
         self.timeout = timeout
         self.status_codes = status_codes
         self.find_string = find_string
+        self.port = port
 
         if not check_rate:
             self.check_rate = 300
@@ -71,6 +72,7 @@ class StatusCake:
                 "Timeout": self.timeout,
                 "StatusCodes": self.status_codes,
                 "FindString": self.find_string,
+                "Port": self.port,
         }
 
         test_id = self.check_test()
@@ -102,6 +104,7 @@ def run_module():
         timeout=dict(type='int', required=False),
         status_codes=dict(type='str', required=False),
         find_string=dict(type='str', required=False),
+        port=dict(type='int', required=False),
     )
 
     module = AnsibleModule(argument_spec=module_args, supports_check_mode=False)
@@ -122,8 +125,9 @@ def run_module():
     timeout = module.params['timeout']
     status_codes = module.params['status_codes']
     find_string = module.params['find_string']
+    port = module.params['port']
 
-    test = StatusCake(module, username, api_key, name, url, state, test_tags, check_rate, test_type, contact_group, user_agent, paused, node_locations, confirmation, timeout, status_codes, find_string)
+    test = StatusCake(module, username, api_key, name, url, state, test_tags, check_rate, test_type, contact_group, user_agent, paused, node_locations, confirmation, timeout, status_codes, find_string, port)
 
     if state == "absent":
         test.delete_test()


### PR DESCRIPTION
* This adds the `FindString` (`find_string` here) parameter to the interface. It is used to look for certain strings in the server response.
* This adds the `Port` (`port` here) parameter to the interface. It is used for TCP checks.

Please [refer to the official docs](https://www.statuscake.com/api/Tests/Updating%20Inserting%20and%20Deleting%20Tests.md) for more information :)